### PR TITLE
Fix flt file read for large npart

### DIFF
--- a/code_fix_floater/FLT.h
+++ b/code_fix_floater/FLT.h
@@ -50,6 +50,7 @@ C           for returning to the surface is called in the profiling routine
 C           flt_int_prof has to be the minimum of all iup(max_npart).
 C           The subsampling of profiles can be done later in the analysis.
 
+
       _RL flt_noise, flt_deltaT
       _RL flt_int_traj, flt_int_prof
       INTEGER FLT_Iter0
@@ -70,9 +71,14 @@ C     flt_file    :: name of the file containing the initial positions.
 C                    At initialization the program first looks for a
 C                    global file flt_file.data. If that is not found it
 C                    looks for tiled files flt_file.iG.jG.data.
-      CHARACTER*(MAX_LEN_FNAM) flt_file
-      COMMON / FLT_PARAM_C / flt_file
+C-------Start Nathaniel Hack ---------------------
+C        flt_npart       :: integer number of floats in flt_file
 
+      INTEGER flt_npart
+      CHARACTER*(MAX_LEN_FNAM) flt_file
+      COMMON / FLT_PARAM_C /
+     &       flt_file, flt_npart
+C---------End Nathaniel Hack-----------------------
 C     mapIniPos2Index :: convert float initial position to (local) index map
       LOGICAL mapIniPos2Index
       COMMON / FLT_PARAM_L / mapIniPos2Index

--- a/code_fix_floater/flt_init_varia.F
+++ b/code_fix_floater/flt_init_varia.F
@@ -119,12 +119,19 @@ C-    read actual number of floats from file
 
       IF ( ioUnit.GT.0 .AND. mapIniPos2Index ) THEN
 C--   Found a global file
-        WRITE(msgBuf,'(A,2I4,A,1P2E15.8)')
-     &    ' bi,bj=', bi, bj, ' , npart,max_npart=', tmp(1), tmp(6)
+C-------Start Nathaniel Hack----------------------
+        IF (flt_npart.EQ.0 ) THEN
+          npart_read = NINT(tmp(1))
+        ELSE
+          npart_read = flt_npart
+        ENDIF
+
+        WRITE(msgBuf,'(A,2I4,A,I4)')
+     &' bi,bj=', bi, bj, ' , npart=', npart_read
         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                       SQUEEZE_RIGHT, myThid )
-        npart_read = NINT(tmp(1))
         max_npart  = tmp(6)
+C-----------------End Hack-----------------------
         DO ip=1,npart_read
 C-    read individual float position from file
           CALL MDS_READVEC_LOC( fn, fp, ioUnit,

--- a/code_fix_floater/flt_init_varia.F
+++ b/code_fix_floater/flt_init_varia.F
@@ -126,8 +126,8 @@ C-------Start Nathaniel Hack----------------------
           npart_read = flt_npart
         ENDIF
 
-        WRITE(msgBuf,'(A,2I4,A,I4)')
-     &' bi,bj=', bi, bj, ' , npart=', npart_read
+        WRITE(msgBuf,'(A,2I4,A,I10)')
+     &' bi,bj=', bi, bj, ' ,hacked npart_read=', npart_read
         CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
      &                       SQUEEZE_RIGHT, myThid )
         max_npart  = tmp(6)

--- a/code_fix_floater/flt_readparms.F
+++ b/code_fix_floater/flt_readparms.F
@@ -1,0 +1,91 @@
+C $Header: /u/gcmpack/MITgcm/pkg/flt/flt_readparms.F,v 1.9 2014/05/27 23:41:28 jmc Exp $
+C $Name: checkpoint65y $
+
+#include "FLT_OPTIONS.h"
+
+      SUBROUTINE FLT_READPARMS( myThid  )
+
+C     ==================================================================
+C     SUBROUTINE FLT_READPARMS
+C     ==================================================================
+C     o read float-pkg parameters from file "data.flt"
+C     ==================================================================
+
+C     !USES:
+      IMPLICIT NONE
+
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "FLT_SIZE.h"
+#include "FLT.h"
+
+C     == routine arguments ==
+C     myThid - thread number for this instance of the routine.
+      INTEGER myThid
+
+C     == local variables ==
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+      INTEGER iUnit
+
+      NAMELIST /FLT_NML/ flt_int_traj, flt_int_prof,
+     &                   flt_selectTrajOutp, flt_selectProfOutp,
+     &                   flt_noise, flt_deltaT, FLT_Iter0,
+     &                   flt_file, mapIniPos2Index, flt_npart
+
+C     == end of interface ==
+
+      IF ( .NOT.useFLT ) THEN
+C-    pkg FLT is not used
+        _BEGIN_MASTER(myThid)
+C-    Track pkg activation status:
+C     print a (weak) warning if data.flt is found
+         CALL PACKAGES_UNUSED_MSG( 'useFLT', ' ', ' ' )
+        _END_MASTER(myThid)
+        RETURN
+      ENDIF
+
+      _BEGIN_MASTER(myThid)
+
+C     Set default values.
+      flt_deltaT   = deltaTClock
+      FLT_Iter0 = 0
+      flt_int_traj =  3600.
+      flt_int_prof = 43200.
+      flt_noise    = 0.0
+      flt_file     = 'float_pos'
+      mapIniPos2Index = .TRUE.
+      flt_selectTrajOutp = 2
+      flt_selectProfOutp = 2
+      flt_npart = 0
+
+      WRITE(msgBuf,'(A)') ' FLT_READPARMS: opening data.flt'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+      CALL OPEN_COPY_DATA_FILE(
+     I                          'data.flt', 'FLT_READPARMS',
+     O                          iUnit,
+     I                          myThid )
+
+C     Read parameters from open data file
+      READ(UNIT=iUnit,NML=FLT_NML)
+      WRITE(msgBuf,'(A)') ' FLT_READPARMS: finished reading data.flt'
+      CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                    SQUEEZE_RIGHT, myThid )
+C     Close the open data file
+      CLOSE(iUnit)
+
+C     Do some checks
+c     IF ( useFLT .AND. useOBCS ) THEN
+c       WRITE(msgBuf,'(A,A)')
+c    &   'S/R FLT_READPARMS: floats currently not implemented',
+c    &   ' with open boundaries'
+c       CALL PRINT_ERROR( msgBuf , myThid)
+c       STOP 'ABNORMAL END: S/R FLT_READPARMS'
+c     ENDIF
+
+      _END_MASTER(myThid)
+      _BARRIER
+
+      RETURN
+      END


### PR DESCRIPTION
For `npart > 1.6 x 10^7`, rounding error generated by type converting from integer to float32 causes `npart_read` to differ from the true number of floats in the `flt_file`. This PR seeks to remedy this problem. We let the user set `flt_npart`, an (integer) parameter to be specified in `data.flt`. If not given, `flt_npart` defaults to zero.  Iff  `flt_npart=0`, a conditional in `flt_init_varia.F` sets `npart_read` equal to the first entry of the `flt_file` (the prior way `npart_read` was specified ). In all other cases, `npart_read=flt_npart` and the `flt_file` should be read in without issue. 