### PR TITLE
fix_pickup

### DIFF
--- a/code_lavd/flt_init_varia.F
+++ b/code_lavd/flt_init_varia.F
@@ -211,8 +211,7 @@ C--   For initial condition only, convert coordinates to index map:
              ENDIF
 C     not a global file: assume that all particles from this tiled-file
 C     belong to this current tile (=> do not no check)
-C             npart(ip,bi,bj)  = tmp(1)
-             npart(ip,bi,bj) = ip
+             npart(ip,bi,bj)  = tmp(1)
              tstart(ip,bi,bj) = tmp(2)
              ipart(ip,bi,bj)  = ix
              jpart(ip,bi,bj)  = jy
@@ -221,6 +220,7 @@ C             npart(ip,bi,bj)  = tmp(1)
              iup(  ip,bi,bj)  = tmp(7)
              itop( ip,bi,bj)  = tmp(8)
              tend( ip,bi,bj)  = tmp(9)
+             lavd( ip,bi,bj) = 0.0
            ENDDO
            CLOSE( ioUnit )
 


### PR DESCRIPTION
The code was not working with restarts (pickup files). We noticed that, when reading the pickups, `npart` was being overwritten. This is what we want for a fresh start, but not for a restart--need to preserve the npart values.

We also need to think about how to handle LAVD with restarts.

